### PR TITLE
Fix mean calculation to avoid integer truncation

### DIFF
--- a/project/utils.py
+++ b/project/utils.py
@@ -1,0 +1,28 @@
+"""Utility functions for basic mathematics."""
+
+from typing import Iterable
+
+
+def mean(values: Iterable[float]) -> float:
+    """Calculate the arithmetic mean of ``values``.
+
+    Parameters
+    ----------
+    values:
+        A non-empty iterable of numbers.
+
+    Returns
+    -------
+    float
+        The average of the provided values.
+
+    Raises
+    ------
+    ValueError
+        If ``values`` is empty.
+    """
+    values = list(values)
+    if not values:
+        raise ValueError("values must not be empty")
+
+    return sum(values) / len(values)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on the import path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+import pytest
+
+from project.utils import mean
+
+
+def test_mean_returns_float():
+    assert mean([1, 2]) == 1.5
+
+
+def test_mean_empty_values():
+    with pytest.raises(ValueError):
+        mean([])


### PR DESCRIPTION
## Summary
- add `mean` utility with proper floating-point division
- validate `mean` input and raise `ValueError` on empty iterables
- include tests for `mean` and configure test import path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0d8547c48330a4bb600105a08c68